### PR TITLE
2087: Upgrade Appium java-client to latest (8.0.0-beta2)

### DIFF
--- a/finder/kotlin/build.gradle.kts
+++ b/finder/kotlin/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.gradle.jvm.tasks.Jar
 
 group = "pro.truongsinh"
-version = "0.0.4"
+version = "0.0.5-forked-SNAPSHOT"
 
 plugins {
     id("kotlinx-serialization") version "1.3.40"
@@ -17,7 +17,9 @@ repositories {
 dependencies {
     implementation(kotlin("stdlib")) 
     implementation ("org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0")
-    implementation ("io.appium:java-client:2.1.0")
+//    implementation ("io.appium:java-client:2.1.0")
+    implementation ("io.appium:java-client:8.0.0-beta2")
+    implementation("org.seleniumhq.selenium:selenium-support:4.1.1")
     testImplementation("junit:junit:4.12")
 }
 

--- a/finder/kotlin/build.gradle.kts
+++ b/finder/kotlin/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.gradle.jvm.tasks.Jar
 
 group = "pro.truongsinh"
-version = "0.0.5-forked-SNAPSHOT"
+version = "1.0.2-forked-SNAPSHOT"
 
 plugins {
     id("kotlinx-serialization") version "1.3.40"

--- a/finder/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/finder/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/finder/kotlin/src/main/kotlin/pro/truongsinh/appium_flutter/FlutterFinder.kt
+++ b/finder/kotlin/src/main/kotlin/pro/truongsinh/appium_flutter/FlutterFinder.kt
@@ -1,9 +1,7 @@
 package pro.truongsinh.appium_flutter
 
 import java.util.regex.Pattern
-import java.io.File
 
-import io.appium.java_client.MobileElement
 import org.openqa.selenium.remote.RemoteWebDriver
 import org.openqa.selenium.remote.FileDetector
 import pro.truongsinh.appium_flutter.finder.FlutterElement

--- a/finder/kotlin/src/main/kotlin/pro/truongsinh/appium_flutter/finder/FlutterElement.kt
+++ b/finder/kotlin/src/main/kotlin/pro/truongsinh/appium_flutter/finder/FlutterElement.kt
@@ -1,8 +1,8 @@
 package pro.truongsinh.appium_flutter.finder
 
-import io.appium.java_client.MobileElement
+import org.openqa.selenium.remote.RemoteWebElement
 
-public class FlutterElement : MobileElement {
+public class FlutterElement : RemoteWebElement {
   private var _rawMap: Map<String, *>
   constructor(m: Map<String, *>) {
     _rawMap = m


### PR DESCRIPTION
1. Update java-client dependency: 8.0.0-beta2
2. Remove the references to obsolete _MobileElement_ class